### PR TITLE
feat: now we can use tsinghua mirror

### DIFF
--- a/basic-config/basic-config.nix
+++ b/basic-config/basic-config.nix
@@ -104,15 +104,28 @@
     pulse.enable = true;
   };
 
-  # Enable flakes
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
-  # Grabage collect settings
-  nix.settings.auto-optimise-store = true;
-  nix.gc = {
-    automatic = true;
-    dates = "daily";
-    options = "--delete-older-than 7d";
+  nix = {
+    settings = {
+      # Enable flakes
+      experimental-features = [ "nix-command" "flakes" ];
+
+      # Grabage collect settings
+      auto-optimise-store = true;
+
+      # Use tsinghua binary cache mirror
+      substituters = [
+        "https://mirrors.tuna.tsinghua.edu.cn/nix-channels/store"
+	"https://cache.nixos.org"
+      ];
+    };
+    # collect garbage everyday
+    gc = {
+      automatic = true;
+      dates = "daily";
+      options = "--delete-older-than 7d";
+    };
   };
+
 
   # This option defines the first version of NixOS you have installed on this particular machine,
   # and is used to maintain compatibility with application data (e.g. databases) created on older NixOS versions.

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,11 @@
 {
   description = "Nanashi's flake.nix";
+  nixConfig = {
+    substituters = [ 
+      "https://mirrors.tuna.tsinghua.edu.cn/nix-channels/store"
+      "https://cache.nixos.org"
+    ];
+  };
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/9df5ff73a8887edc8fb69a9facf3b7f6e8ed17d7";


### PR DESCRIPTION
 - however, it likes tsinghua do not mirror all content of cache.nixos.org, so I keep it as fallback. (Otherwise I must build it myself!)
 - sjtu mirror is another mirror, but seems like it can not function now. (Return 502 error)
 - maybe close Yxue-1906/nixos-common-config#11