### PR TITLE
fix: make file-roller use `rar` to handle rar archives correctly

### DIFF
--- a/applications/applications.nix
+++ b/applications/applications.nix
@@ -32,6 +32,8 @@
     git-crypt
     home-manager
     _7zz
+    # make file-roller happy
+    rar
     zotero
   ];
 }


### PR DESCRIPTION
ref: Yxue-1906/nixos-common-config#10 