### PR TITLE
feat: add local ariang

### DIFF
--- a/applications/aria2.nix
+++ b/applications/aria2.nix
@@ -1,4 +1,4 @@
-{lib, config, options, nixpkgs-24_11, secrets, ...}: {
+{lib, config, options, pkgs, nixpkgs-24_11, secrets, ...}: {
   services.aria2 = {
     enable = true;
     rpcSecretFile = secrets.aria2.secret-file;
@@ -421,5 +421,13 @@
 
   systemd.services.aria2.serviceConfig = {
     UMask = "0002";
+  };
+
+  # Enable local ariang server
+  services.nginx.virtualHosts.localhost = {
+    locations."/ariang/" = {
+      alias = "${pkgs.ariang}/share/ariang/";
+      index = "index.html";
+    };
   };
 }

--- a/applications/default.nix
+++ b/applications/default.nix
@@ -15,4 +15,6 @@
   # Allow Unfree
   nixpkgs.config.allowUnfree = true;
   
+  # Enable local Nginx
+  services.nginx.enable = true;
 }


### PR DESCRIPTION
Motivation:
- Provide a local version of ariang, so I would not go to other live version to manage local ariang

Changes:
- enable `nginx` server in `applications/default.nix`
- add related service block for nginx in `applications/aria2.nix`

Output:
- it can be accessed from http://localhost/ariang/