### PR TITLE
feat: use x11 instead of wayland to gain more stable experience

### DIFF
--- a/applications/default.nix
+++ b/applications/default.nix
@@ -8,6 +8,7 @@
     ./browsers.nix
     ./misc.nix
     ./nautilus
+    # ./mutter
     ./file-roller
   ];
 

--- a/basic-config/window.nix
+++ b/basic-config/window.nix
@@ -4,14 +4,15 @@
     enable = true;
     displayManager.gdm = {
       enable = true;
+      wayland = false;
     };
     desktopManager.gnome = {
       enable = true;
-      extraGSettingsOverridePackages = [ pkgs.mutter ];
-      extraGSettingsOverrides = ''
-        [org.gnome.mutter]
-        experimental-features=['scale-monitor-framebuffer']
-      '';
+      # extraGSettingsOverridePackages = [ pkgs.mutter ];
+      # extraGSettingsOverrides = ''
+      #   [org.gnome.mutter]
+      #   experimental-features=['scale-monitor-framebuffer']
+      # '';
     };
     xkb = {
       layout = "cn";


### PR DESCRIPTION
Motivation:
This PR is to replace wayland to x11 to gain better experience.

Changes: 
- set wayland to false
- disable mutter overrides

Test:
`nixos-rebuild switch` success